### PR TITLE
feat(lotto-history): 번호 랭킹 UI 추가 및 FSD 최소 분리 리팩토링

### DIFF
--- a/.storybook/main.ts
+++ b/.storybook/main.ts
@@ -1,25 +1,22 @@
-import type { StorybookConfig } from '@storybook/react-vite';
-import path from 'path';
+import type { StorybookConfig } from "@storybook/react-vite";
+import path from "path";
 
 const config: StorybookConfig = {
-  stories: ['../src/**/*.stories.@(js|jsx|mjs|ts|tsx)'],
-  addons: [
-    '@storybook/addon-docs',
-  ],
+  stories: ["../src/**/*.stories.@(js|jsx|mjs|ts|tsx)"],
+  addons: ["@storybook/addon-docs"],
   framework: {
-    name: '@storybook/react-vite',
+    name: "@storybook/react-vite",
     options: {},
   },
   typescript: {
-    reactDocgen: 'react-docgen-typescript',
+    reactDocgen: "react-docgen-typescript",
   },
   viteFinal: async (config) => {
-    // alias 설정 추가 (메인 프로젝트와 동일하게)
     config.resolve = {
       ...config.resolve,
       alias: {
         ...config.resolve?.alias,
-        '@': path.resolve(__dirname, '../src'),
+        "@": path.resolve(__dirname, "../src"),
       },
     };
 

--- a/src/entities/lotto/model.ts
+++ b/src/entities/lotto/model.ts
@@ -1,0 +1,28 @@
+import type { BallProps } from "../../shared/ui/Ball/Ball";
+
+export type HistoryBall = { number: number; color: BallProps["color"] };
+
+export type HistoryItem = {
+  id: string;
+  title: string;
+  date?: string;
+  balls: HistoryBall[];
+  bonusBall?: HistoryBall;
+  footerLeft?: string;
+  footerRight?: string;
+  participated?: boolean;
+};
+
+export type RankingItem = {
+  rank: number;
+  number: number;
+  color: BallProps["color"];
+};
+
+export const getColorByNumber = (n: number): BallProps["color"] => {
+  if (n >= 1 && n <= 10) return "yellow";
+  if (n >= 11 && n <= 20) return "blue";
+  if (n >= 21 && n <= 30) return "red";
+  if (n >= 31 && n <= 40) return "gray";
+  return "green";
+};

--- a/src/pages/lotto-history/index.tsx
+++ b/src/pages/lotto-history/index.tsx
@@ -1,9 +1,10 @@
 import { useMemo, useRef, useState } from "react";
-import { SegmentedControl, Typography, Chip, Checkbox } from "../../shared/ui";
-import Card from "../../shared/ui/Card";
+import { SegmentedControl, Typography } from "../../shared/ui";
 import { FloatButton } from "../../shared/ui/Button/FloatButton";
 import colors from "../../shared/design-tokens/color";
 import { historyMock, rankingMock } from "./mock";
+import HistoryList from "../../widgets/lotto-history/HistoryList";
+import RankingPanel from "../../widgets/lotto-history/RankingPanel";
 
 const LottoHistory = () => {
   const [activeTab, setActiveTab] = useState<"history" | "ranking">("history");
@@ -65,77 +66,15 @@ const LottoHistory = () => {
       <div ref={contentRef} className="flex-1 overflow-y-auto">
         <div className="max-w-md mx-auto px-6 space-y-4 relative">
           {activeTab === "history" ? (
-            <div className="space-y-3">
-              {historyMock.map((item) => {
-                const chipVisible = item.participated === true;
-                const chipLabel = item.participated ? "참여" : "미참여";
-
-                return (
-                  <Card
-                    key={item.id}
-                    size="M"
-                    state={
-                      item.participated === undefined
-                        ? "not_joined"
-                        : item.participated
-                          ? "joined"
-                          : "not_joined"
-                    }
-                    title={item.title}
-                    date={item.date}
-                    chipVisible={chipVisible}
-                    chipLabel={chipLabel}
-                    balls={item.balls}
-                    bonusBall={item.bonusBall}
-                    footerLeft={item.footerLeft}
-                    footerRight={item.footerRight}
-                  />
-                );
-              })}
-            </div>
+            <HistoryList items={historyMock} />
           ) : (
-            <>
-              <div className="sticky top-0 z-30 bg-primary-9 pt-4 pb-3 flex items-center justify-between">
-                <div className="flex items-center gap-2">
-                  <Chip
-                    variant={rankingSort === "rank" ? "solid" : "tinted"}
-                    color="primary"
-                    onClick={() => setRankingSort("rank")}
-                  >
-                    랭킹순
-                  </Chip>
-                  <Chip
-                    variant={rankingSort === "number" ? "solid" : "tinted"}
-                    color="primary"
-                    onClick={() => setRankingSort("number")}
-                  >
-                    번호순
-                  </Chip>
-                </div>
-                <Checkbox
-                  checked={includeBonus}
-                  onChange={(checked) => setIncludeBonus(checked)}
-                  label="보너스 포함"
-                />
-              </div>
-              <div
-                className="sticky top-[52px] z-30 h-px w-full"
-                style={{ background: colors.gradient.component.direction }}
-              />
-
-              <div className="grid grid-cols-1 gap-3 relative z-0">
-                {rankingList.map((r) => (
-                  <Card
-                    key={`${r.rank}-${r.number}`}
-                    title={`${r.number}회`}
-                    size="S"
-                    state={r.rank === 1 ? "rank1" : "default"}
-                    rank={r.rank}
-                    ball={{ number: r.number, color: r.color }}
-                  />
-                ))}
-              </div>
-            </>
+            <RankingPanel
+              list={rankingList}
+              rankingSort={rankingSort}
+              setRankingSort={setRankingSort}
+              includeBonus={includeBonus}
+              setIncludeBonus={setIncludeBonus}
+            />
           )}
           <div className="sticky bottom-6 flex justify-end pointer-events-none z-10">
             <div className="pointer-events-auto">

--- a/src/pages/lotto-history/index.tsx
+++ b/src/pages/lotto-history/index.tsx
@@ -1,54 +1,148 @@
-import { useState } from "react";
+import { useMemo, useRef, useState } from "react";
+import { SegmentedControl, Typography, Chip, Checkbox } from "../../shared/ui";
+import Card from "../../shared/ui/Card";
+import { FloatButton } from "../../shared/ui/Button/FloatButton";
+import colors from "../../shared/design-tokens/color";
+import { historyMock, rankingMock } from "./mock";
 
 const LottoHistory = () => {
   const [activeTab, setActiveTab] = useState<"history" | "ranking">("history");
+  const contentRef = useRef<HTMLDivElement>(null);
+  const scrollToTop = () => {
+    contentRef.current?.scrollTo({ top: 0, behavior: "smooth" });
+  };
+
+  const [rankingSort, setRankingSort] = useState<"rank" | "number">("rank");
+  const [includeBonus, setIncludeBonus] = useState(false);
+
+  const rankingList = useMemo(() => {
+    const list = [...rankingMock];
+    if (rankingSort === "rank") {
+      list.sort((a, b) => a.rank - b.rank);
+    } else {
+      list.sort((a, b) => a.number - b.number);
+    }
+    return list;
+  }, [rankingSort, includeBonus]);
+
+  const tabs = useMemo(
+    () => [
+      { label: "지난 번호", value: "history" },
+      { label: "번호 랭킹", value: "ranking" },
+    ],
+    []
+  );
 
   return (
-    <div className="min-h-screen bg-gray-50">
-      {/* Header */}
-      <div className="bg-white shadow-sm">
-        <div className="max-w-md mx-auto px-4 py-6">
-          <h1 className="text-2xl font-bold text-gray-900 text-center mb-6">
+    <div className="h-screen bg-primary-9 flex flex-col">
+      <div className="bg-primary-9">
+        <div className="max-w-md mx-auto px-6 pt-6 pb-4">
+          <Typography
+            as="h1"
+            variant="heading-24"
+            className="text-2xl font-bold text-gray-1 text-center"
+          >
             뭐 나왔지
-          </h1>
+          </Typography>
 
-          {/* Tab Navigation */}
-          <div className="flex bg-gray-100 rounded-lg p-1">
-            <button
-              onClick={() => setActiveTab("history")}
-              className={`flex-1 py-3 px-4 rounded-md text-sm font-medium transition-colors ${
-                activeTab === "history"
-                  ? "bg-white text-gray-900 shadow-sm"
-                  : "text-gray-500 hover:text-gray-700"
-              }`}
-            >
-              지난 번호
-            </button>
-            <button
-              onClick={() => setActiveTab("ranking")}
-              className={`flex-1 py-3 px-4 rounded-md text-sm font-medium transition-colors ${
-                activeTab === "ranking"
-                  ? "bg-white text-gray-900 shadow-sm"
-                  : "text-gray-500 hover:text-gray-700"
-              }`}
-            >
-              번호 랭킹
-            </button>
+          <div className="mt-6 flex justify-center">
+            <SegmentedControl
+              value={activeTab}
+              options={tabs}
+              onChange={(v) => setActiveTab(v as "history" | "ranking")}
+              color="primary"
+            />
           </div>
         </div>
+        <div
+          className="h-[1px] w-full"
+          style={{ background: colors.gradient.component.direction }}
+          role="separator"
+          aria-orientation="horizontal"
+        />
       </div>
 
-      {/* Content */}
-      <div className="max-w-md mx-auto px-4 py-6">
-        {activeTab === "history" ? (
-          <div className="text-center text-gray-500">
-            지난 번호 내용이 여기에 표시됩니다.
+      <div ref={contentRef} className="flex-1 overflow-y-auto">
+        <div className="max-w-md mx-auto px-6 space-y-4 relative">
+          {activeTab === "history" ? (
+            <div className="space-y-3">
+              {historyMock.map((item) => {
+                const chipVisible = item.participated === true;
+                const chipLabel = item.participated ? "참여" : "미참여";
+
+                return (
+                  <Card
+                    key={item.id}
+                    size="M"
+                    state={
+                      item.participated === undefined
+                        ? "not_joined"
+                        : item.participated
+                          ? "joined"
+                          : "not_joined"
+                    }
+                    title={item.title}
+                    date={item.date}
+                    chipVisible={chipVisible}
+                    chipLabel={chipLabel}
+                    balls={item.balls}
+                    bonusBall={item.bonusBall}
+                    footerLeft={item.footerLeft}
+                    footerRight={item.footerRight}
+                  />
+                );
+              })}
+            </div>
+          ) : (
+            <>
+              <div className="sticky top-0 z-30 bg-primary-9 pt-4 pb-3 flex items-center justify-between">
+                <div className="flex items-center gap-2">
+                  <Chip
+                    variant={rankingSort === "rank" ? "solid" : "tinted"}
+                    color="primary"
+                    onClick={() => setRankingSort("rank")}
+                  >
+                    랭킹순
+                  </Chip>
+                  <Chip
+                    variant={rankingSort === "number" ? "solid" : "tinted"}
+                    color="primary"
+                    onClick={() => setRankingSort("number")}
+                  >
+                    번호순
+                  </Chip>
+                </div>
+                <Checkbox
+                  checked={includeBonus}
+                  onChange={(checked) => setIncludeBonus(checked)}
+                  label="보너스 포함"
+                />
+              </div>
+              <div
+                className="sticky top-[52px] z-30 h-px w-full"
+                style={{ background: colors.gradient.component.direction }}
+              />
+
+              <div className="grid grid-cols-1 gap-3 relative z-0">
+                {rankingList.map((r) => (
+                  <Card
+                    key={`${r.rank}-${r.number}`}
+                    title={`${r.number}회`}
+                    size="S"
+                    state={r.rank === 1 ? "rank1" : "default"}
+                    rank={r.rank}
+                    ball={{ number: r.number, color: r.color }}
+                  />
+                ))}
+              </div>
+            </>
+          )}
+          <div className="sticky bottom-6 flex justify-end pointer-events-none z-10">
+            <div className="pointer-events-auto">
+              <FloatButton onClick={scrollToTop} />
+            </div>
           </div>
-        ) : (
-          <div className="text-center text-gray-500">
-            번호 랭킹 내용이 여기에 표시됩니다.
-          </div>
-        )}
+        </div>
       </div>
     </div>
   );

--- a/src/pages/lotto-history/mock.ts
+++ b/src/pages/lotto-history/mock.ts
@@ -1,0 +1,202 @@
+import type { BallProps } from "../../shared/ui/Ball/Ball";
+
+export type HistoryBall = { number: number; color: BallProps["color"] };
+
+export type HistoryItem = {
+  id: string;
+  title: string;
+  date?: string;
+  balls: HistoryBall[];
+  bonusBall?: HistoryBall;
+  footerLeft?: string;
+  footerRight?: string;
+  participated?: boolean;
+};
+
+export const historyMock: HistoryItem[] = [
+  {
+    id: "1120",
+    title: "제 1120회",
+    date: "2025.08.09",
+    balls: [
+      { number: 3, color: "yellow" },
+      { number: 12, color: "blue" },
+      { number: 18, color: "blue" },
+      { number: 27, color: "red" },
+      { number: 28, color: "red" },
+      { number: 33, color: "gray" },
+    ],
+    bonusBall: { number: 41, color: "green" },
+    footerLeft: "총 당첨자 12명",
+    footerRight: "1등 2명",
+    participated: true,
+  },
+  {
+    id: "1119",
+    title: "제 1119회",
+    date: "2025.08.02",
+    balls: [
+      { number: 7, color: "yellow" },
+      { number: 11, color: "blue" },
+      { number: 20, color: "blue" },
+      { number: 21, color: "red" },
+      { number: 29, color: "red" },
+      { number: 36, color: "gray" },
+    ],
+    bonusBall: { number: 44, color: "green" },
+    footerLeft: "총 당첨자 8명",
+    footerRight: "1등 1명",
+  },
+  {
+    id: "1118",
+    title: "제 1118회",
+    date: "2025.07.26",
+    balls: [
+      { number: 2, color: "yellow" },
+      { number: 9, color: "blue" },
+      { number: 13, color: "blue" },
+      { number: 23, color: "red" },
+      { number: 28, color: "red" },
+      { number: 31, color: "gray" },
+    ],
+    bonusBall: { number: 40, color: "green" },
+    footerLeft: "총 당첨자 15명",
+    footerRight: "1등 3명",
+  },
+  {
+    id: "1117",
+    title: "제 1117회",
+    date: "2025.07.19",
+    balls: [
+      { number: 5, color: "yellow" },
+      { number: 14, color: "blue" },
+      { number: 19, color: "blue" },
+      { number: 22, color: "red" },
+      { number: 27, color: "red" },
+      { number: 34, color: "gray" },
+    ],
+    bonusBall: { number: 43, color: "green" },
+    footerLeft: "총 당첨자 10명",
+    footerRight: "1등 2명",
+    participated: true,
+  },
+  {
+    id: "1116",
+    title: "제 1116회",
+    date: "2025.07.12",
+    balls: [
+      { number: 6, color: "yellow" },
+      { number: 11, color: "blue" },
+      { number: 17, color: "blue" },
+      { number: 24, color: "red" },
+      { number: 30, color: "red" },
+      { number: 35, color: "gray" },
+    ],
+    bonusBall: { number: 41, color: "green" },
+    footerLeft: "총 당첨자 9명",
+    footerRight: "1등 1명",
+  },
+  {
+    id: "1115",
+    title: "제 1115회",
+    date: "2025.07.05",
+    balls: [
+      { number: 1, color: "yellow" },
+      { number: 12, color: "blue" },
+      { number: 18, color: "blue" },
+      { number: 21, color: "red" },
+      { number: 26, color: "red" },
+      { number: 32, color: "gray" },
+    ],
+    bonusBall: { number: 45, color: "green" },
+    footerLeft: "총 당첨자 11명",
+    footerRight: "1등 2명",
+  },
+  {
+    id: "1114",
+    title: "제 1114회",
+    date: "2025.06.28",
+    balls: [
+      { number: 10, color: "yellow" },
+      { number: 16, color: "blue" },
+      { number: 20, color: "blue" },
+      { number: 25, color: "red" },
+      { number: 29, color: "red" },
+      { number: 37, color: "gray" },
+    ],
+    bonusBall: { number: 41, color: "green" },
+    footerLeft: "총 당첨자 7명",
+    footerRight: "1등 1명",
+    participated: true,
+  },
+  {
+    id: "1113",
+    title: "제 1113회",
+    date: "2025.06.21",
+    balls: [
+      { number: 8, color: "yellow" },
+      { number: 11, color: "blue" },
+      { number: 12, color: "blue" },
+      { number: 23, color: "red" },
+      { number: 27, color: "red" },
+      { number: 31, color: "gray" },
+    ],
+    bonusBall: { number: 42, color: "green" },
+    footerLeft: "총 당첨자 13명",
+    footerRight: "1등 3명",
+  },
+  {
+    id: "1112",
+    title: "제 1112회",
+    date: "2025.06.14",
+    balls: [
+      { number: 9, color: "yellow" },
+      { number: 14, color: "blue" },
+      { number: 19, color: "blue" },
+      { number: 22, color: "red" },
+      { number: 28, color: "red" },
+      { number: 33, color: "gray" },
+    ],
+    bonusBall: { number: 41, color: "green" },
+    footerLeft: "총 당첨자 6명",
+    footerRight: "1등 1명",
+    participated: true,
+  },
+  {
+    id: "1111",
+    title: "제 1111회",
+    date: "2025.06.07",
+    balls: [
+      { number: 4, color: "yellow" },
+      { number: 13, color: "blue" },
+      { number: 17, color: "blue" },
+      { number: 21, color: "red" },
+      { number: 30, color: "red" },
+      { number: 36, color: "gray" },
+    ],
+    bonusBall: { number: 44, color: "green" },
+    footerLeft: "총 당첨자 5명",
+    footerRight: "1등 1명",
+  },
+];
+
+export type RankingItem = {
+  rank: number;
+  number: number;
+  color: BallProps["color"];
+};
+
+export const getColorByNumber = (n: number): BallProps["color"] => {
+  if (n >= 1 && n <= 10) return "yellow";
+  if (n >= 11 && n <= 20) return "blue";
+  if (n >= 21 && n <= 30) return "red";
+  if (n >= 31 && n <= 40) return "gray";
+  return "green";
+};
+
+export const rankingMock: RankingItem[] = Array.from({ length: 50 }).map(
+  (_, i) => {
+    const number = (i % 50) + 1;
+    return { rank: i + 1, number, color: getColorByNumber(number) };
+  }
+);

--- a/src/shared/ui/Card/Card.stories.tsx
+++ b/src/shared/ui/Card/Card.stories.tsx
@@ -34,7 +34,6 @@ export default meta;
 
 type Story = StoryObj<typeof Card>;
 
-// helpers
 const sampleBalls = [
   { number: 4, color: "yellow" as const },
   { number: 12, color: "blue" as const },

--- a/src/shared/ui/Card/Card.styles.ts
+++ b/src/shared/ui/Card/Card.styles.ts
@@ -12,7 +12,7 @@ export const cardM = {
     cardBase.bg,
     cardRadius.container,
 
-    "p-4 flex flex-col gap-4 w-[327px]",
+    "p-4 flex flex-col gap-4",
   ].join(" "),
   header: ["flex flex-row items-center gap-[6px] w-full"].join(" "),
   title: [
@@ -22,8 +22,10 @@ export const cardM = {
   date: [
     "text-[12px] leading-6 font-medium tracking-[-0.015em] text-gray-4",
   ].join(" "),
-  ballsRow: ["flex flex-row items-center gap-2 w-full"].join(" "),
-  bonusDivider: ["text-gray-3 text-[10px] leading-6 font-bold mx-1"].join(" "),
+  ballsRow: ["flex flex-row items-center justify-between w-full"].join(" "),
+  bonusDivider: [
+    "flex items-center justify-center text-gray-3 w-[10px] h-[10px] leading-6 font-bold mx-1",
+  ].join(" "),
   ballWrap: ["relative w-8 h-8"].join(" "),
   ballNumber: [
     "absolute inset-0 flex items-center justify-center text-[14px] leading-6 font-extrabold tracking-[-0.015em] text-white",
@@ -47,7 +49,7 @@ export const cardS = {
     cardBase.bg,
     cardRadius.container,
 
-    "w-[327px] h-[77px] px-5 py-4 flex flex-row items-center gap-4",
+    " h-[77px] px-5 py-4 flex flex-row items-center gap-4",
   ].join(" "),
   ballWrap: ["relative w-8 h-8"].join(" "),
   ballNumber: [

--- a/src/shared/ui/Typography/Typography.stories.tsx
+++ b/src/shared/ui/Typography/Typography.stories.tsx
@@ -196,9 +196,7 @@ export const Caption: Story = {
   ),
 };
 
-// Typography 테이블 데이터
 const typographyData = [
-  // Display
   {
     name: "28_B",
     variant: "display-28" as const,
@@ -218,7 +216,6 @@ const typographyData = [
     letterSpacing: "-1.5%",
   },
 
-  // Heading
   {
     name: "24_B",
     variant: "heading-24" as const,
@@ -292,7 +289,6 @@ const typographyData = [
     letterSpacing: "-1.5%",
   },
 
-  // Body
   {
     name: "18_B",
     variant: "body-18" as const,
@@ -402,7 +398,6 @@ const typographyData = [
     letterSpacing: "-1.5%",
   },
 
-  // Caption
   {
     name: "12_B",
     variant: "caption-12" as const,

--- a/src/widgets/lotto-history/HistoryList.tsx
+++ b/src/widgets/lotto-history/HistoryList.tsx
@@ -1,0 +1,41 @@
+import Card from "../../shared/ui/Card";
+import type { HistoryItem } from "../../entities/lotto/model";
+
+interface HistoryListProps {
+  items: HistoryItem[];
+}
+
+export const HistoryList = ({ items }: HistoryListProps) => {
+  return (
+    <div className="space-y-3">
+      {items.map((item) => {
+        const chipVisible = item.participated === true;
+        const chipLabel = item.participated ? "참여" : "미참여";
+
+        return (
+          <Card
+            key={item.id}
+            size="M"
+            state={
+              item.participated === undefined
+                ? "not_joined"
+                : item.participated
+                ? "joined"
+                : "not_joined"
+            }
+            title={item.title}
+            date={item.date}
+            chipVisible={chipVisible}
+            chipLabel={chipLabel}
+            balls={item.balls}
+            bonusBall={item.bonusBall}
+            footerLeft={item.footerLeft}
+            footerRight={item.footerRight}
+          />
+        );
+      })}
+    </div>
+  );
+};
+
+export default HistoryList;

--- a/src/widgets/lotto-history/RankingPanel.tsx
+++ b/src/widgets/lotto-history/RankingPanel.tsx
@@ -1,0 +1,67 @@
+import { Chip, Checkbox } from "../../shared/ui";
+import Card from "../../shared/ui/Card";
+import colors from "../../shared/design-tokens/color";
+import type { RankingItem } from "../../entities/lotto/model";
+
+interface RankingPanelProps {
+  list: RankingItem[];
+  rankingSort: "rank" | "number";
+  setRankingSort: (v: "rank" | "number") => void;
+  includeBonus: boolean;
+  setIncludeBonus: (v: boolean) => void;
+}
+
+export const RankingPanel = ({
+  list,
+  rankingSort,
+  setRankingSort,
+  includeBonus,
+  setIncludeBonus,
+}: RankingPanelProps) => {
+  return (
+    <>
+      <div className="sticky top-0 z-30 bg-primary-9 pt-4 pb-3 flex items-center justify-between">
+        <div className="flex items-center gap-2">
+          <Chip
+            variant={rankingSort === "rank" ? "solid" : "tinted"}
+            color="primary"
+            onClick={() => setRankingSort("rank")}
+          >
+            랭킹순
+          </Chip>
+          <Chip
+            variant={rankingSort === "number" ? "solid" : "tinted"}
+            color="primary"
+            onClick={() => setRankingSort("number")}
+          >
+            번호순
+          </Chip>
+        </div>
+        <Checkbox
+          checked={includeBonus}
+          onChange={(checked) => setIncludeBonus(checked)}
+          label="보너스 포함"
+        />
+      </div>
+      <div
+        className="sticky top-[52px] z-30 h-px w-full"
+        style={{ background: colors.gradient.component.direction }}
+      />
+
+      <div className="grid grid-cols-1 gap-3 relative z-0">
+        {list.map((r) => (
+          <Card
+            key={`${r.rank}-${r.number}`}
+            title={`${r.number}회`}
+            size="S"
+            state={r.rank === 1 ? "rank1" : "default"}
+            rank={r.rank}
+            ball={{ number: r.number, color: r.color }}
+          />
+        ))}
+      </div>
+    </>
+  );
+};
+
+export default RankingPanel;


### PR DESCRIPTION
### 변경 요약
- 지난 번호/번호 랭킹 탭 구조 유지, 콘텐츠 영역만 스크롤되도록 개선
- 번호 랭킹 탭에 정렬 Chip(랭킹순/번호순) + ‘보너스 포함’ Checkbox 추가
- Chip/Checkbox 고정(sticky) 및 z-index/배경 처리로 리스트 위 겹침 이슈 해결
- 정렬 상태에 따라 rankingList 메모이제이션
- FSD 최소 분리 적용: 페이지는 상태/레이아웃, 세부 UI는 widgets로 위임
- 도메인 타입/유틸을 entities로 이동
